### PR TITLE
Support use of object-editor-react in server-side rendering contexts

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -24,7 +24,6 @@ import IconButton from '@material-ui/core/IconButton';
 import BaseTable, { BASE_EDITOR_PROPTYPES } from './BaseTable'
 
 import ReactDOM from 'react-dom'
-window.findDOMNode = ReactDOM.findDOMNode.bind(ReactDOM)
 
 import * as Schema from './Schema';
 import { getSchemaTypeIdentifier, SchemaPopover } from './SchemaView'

--- a/src/HoverPopover.js
+++ b/src/HoverPopover.js
@@ -12,9 +12,11 @@ import PropTypes from 'prop-types'
 const lastMousePosition = (() => {
   let latest = null
 
-  eventOnce('load', () => {
-    window.addEventListener('mousemove', evt => (latest = evt.target))
-  })(window)
+  if (typeof window !== 'undefined') {
+    eventOnce('load', () => {
+      window.addEventListener('mousemove', evt => (latest = evt.target))
+    })(window)
+  }
 
   return () => latest
 })()


### PR DESCRIPTION
Fixes two unsafe uses of `window` which prevented object-editor-react from rendering on the server side.