### PR TITLE
Add support for custom rendering of primitive cells

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -385,14 +385,17 @@ class StringCell extends React.Component {
       BaseClassnames.EditorInput('--value')
     );
 
+    const cellContent = typeof this.props.type.render === 'function'
+      ? this.props.type.render(this.props.type, this.props.value, this.props.onChange)
+      : <input
+        className={inputClasses}
+        value={this.props.value || ''}
+        required={this.props.type.required}
+        onChange={evt => this.props.onChange(evt.target.value)}/>
+
     return (
       <TableCell className={BaseClassnames.Cell('--value')}>
-        <input
-          className={inputClasses}
-          type='text'
-          value={this.props.value || ''}
-          required={this.props.type.required}
-          onChange={evt => this.props.onChange(evt.target.value)}/>
+        {cellContent}
       </TableCell>
     );
   }
@@ -421,15 +424,19 @@ class BooleanCell extends React.Component {
   };
 
   render () {
+    const cellContent = typeof this.props.type.render === 'function'
+      ? this.props.type.render(this.props.type, this.props.value, this.props.onChange)
+      : <Select
+        native
+        value={String(Boolean(this.props.value))}
+        onChange={evt => this.props.onChange(stringToBoolean(evt.target.value))}>
+        <option value={true}>True</option>
+        <option value={false}>False</option>
+      </Select>
+
     return (
       <TableCell className={BaseClassnames.Cell('--value')}>
-        <Select
-          native
-          value={String(Boolean(this.props.value))}
-          onChange={evt => this.props.onChange(stringToBoolean(evt.target.value))}>
-          <option value={true}>True</option>
-          <option value={false}>False</option>
-        </Select>
+        { cellContent }
       </TableCell>
     );
   }

--- a/src/examples/example.js
+++ b/src/examples/example.js
@@ -17,7 +17,13 @@ const APP_ROOT = document.getElementById('root')
 
 // A deeply nested test schema
 const schema = {
-    foo: Schema.SchemaTypes.string({ required: true }),
+    foo: Schema.SchemaTypes.string({
+      required: true,
+      render: (type, value, onChange) => <textarea
+        value={value || ''}
+        required={type.required}
+        onChange={evt => onChange(evt.target.value)}/>
+    }),
 
     bar: Schema.SchemaTypes.number(),
 


### PR DESCRIPTION
Primitive schema types now accept a `render` function, which handles rendering of cell.
This render function enables use of `<textarea>` for longer input fields.

The `render` function accepts the following parameters:

```ts
function render(
  type: SchemaType, 
  value: string | number | boolean, 
  onChange: (value: string | number | boolean) => void
): React.ReactNode
```